### PR TITLE
Adjustments for compiling open-bldc without any errors

### DIFF
--- a/source/firmware/src/gprot.c
+++ b/source/firmware/src/gprot.c
@@ -31,7 +31,7 @@
 
 #include "config.h"
 
-#include <stm32/gpio.h>
+#include <libopencm3/stm32/f1/gpio.h>
 
 #include "types.h"
 

--- a/source/libgovernor/configure.ac
+++ b/source/libgovernor/configure.ac
@@ -85,7 +85,7 @@ AC_HEADER_STAT
 # Checks for typedefs, structures, and compiler characteristics.
 # ==============================================================
 
-AM_C_PROTOTYPES
+dnl AM_C_PROTOTYPES
 AC_C_CONST
 AC_TYPE_UID_T     dnl This checks for gid_t too.
 dnl AC_CHECK_TYPES([ssize_t])


### PR DESCRIPTION
Using autoconf Version 2.69 on Arch Linux
